### PR TITLE
Get screen h/w when ran from commandline

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -45,6 +45,8 @@ public class Wallpaperize.Application : Granite.Application {
     }
 
     public override void open (File[] files, string hint) {
+        Wallpaperize.Wallpaperiser.H = Gdk.Screen.height ();
+        Wallpaperize.Wallpaperiser.W = Gdk.Screen.width ();
         foreach (var file in files) {
             Wallpaperize.Wallpaperiser.from_file (file); 
         }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -45,7 +45,7 @@ public class Wallpaperize.Application : Granite.Application {
     }
 
     public override void open (File[] files, string hint) {
-        Wallpaperize.Wallpaperiser.get_monitor_geometry();
+        Wallpaperize.Wallpaperiser.get_monitor_geometry ();
         foreach (var file in files) {
             Wallpaperize.Wallpaperiser.from_file (file); 
         }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -45,8 +45,7 @@ public class Wallpaperize.Application : Granite.Application {
     }
 
     public override void open (File[] files, string hint) {
-        Wallpaperize.Wallpaperiser.H = Gdk.Screen.height ();
-        Wallpaperize.Wallpaperiser.W = Gdk.Screen.width ();
+        Wallpaperize.Wallpaperiser.get_monitor_geometry();
         foreach (var file in files) {
             Wallpaperize.Wallpaperiser.from_file (file); 
         }

--- a/src/Wallpaperize.vala
+++ b/src/Wallpaperize.vala
@@ -24,12 +24,12 @@ public class Wallpaperize.Wallpaperiser : Object {
     }
 
     public static void get_monitor_geometry() {
-        Gdk.Screen screen = Gdk.Screen.get_default();
-        int primary_monitor = screen.get_primary_monitor();
+        var screen = Gdk.Screen.get_default ();
+        int primary_monitor = screen.get_primary_monitor ();
         Gdk.Rectangle geometry;
-        screen.get_monitor_geometry(primary_monitor, out geometry);
+        screen.get_monitor_geometry (primary_monitor, out geometry);
 
-        int monitor_scale = screen.get_monitor_scale_factor(primary_monitor);
+        int monitor_scale = screen.get_monitor_scale_factor (primary_monitor);
         Wallpaperize.Wallpaperiser.H = geometry.height * monitor_scale;
         Wallpaperize.Wallpaperiser.W = geometry.width * monitor_scale;
     }

--- a/src/Wallpaperize.vala
+++ b/src/Wallpaperize.vala
@@ -13,8 +13,8 @@ public class Wallpaperize.Wallpaperiser : Object {
 
     public static void from_file (File file) {
       var path = file.get_path ();
-
-      string output_name = path.replace (".png", "").replace (".jpg", "") + ".wp.png";
+      var file_regex = new Regex (".(jp(e)g|png|tiff|gif)");
+      string output_name = file_regex.replace (path, -1, 0,"") + ".wp.png";
       make_image (path, output_name);
     }
 

--- a/src/Wallpaperize.vala
+++ b/src/Wallpaperize.vala
@@ -23,6 +23,17 @@ public class Wallpaperize.Wallpaperiser : Object {
       }
     }
 
+    public static void get_monitor_geometry() {
+        Gdk.Screen screen = Gdk.Screen.get_default();
+        int primary_monitor = screen.get_primary_monitor();
+        Gdk.Rectangle geometry;
+        screen.get_monitor_geometry(primary_monitor, out geometry);
+
+        int monitor_scale = screen.get_monitor_scale_factor(primary_monitor);
+        Wallpaperize.Wallpaperiser.H = geometry.height * monitor_scale;
+        Wallpaperize.Wallpaperiser.W = geometry.width * monitor_scale;
+    }
+
     // from switchboard-plug-pantheon-shell set-wallpaper.vala
     public static void set_wallpaper (string uri) {
         var settings = new Settings ("org.gnome.desktop.background");

--- a/src/Wallpaperize.vala
+++ b/src/Wallpaperize.vala
@@ -13,9 +13,13 @@ public class Wallpaperize.Wallpaperiser : Object {
 
     public static void from_file (File file) {
       var path = file.get_path ();
-      var file_regex = new Regex (".(jp(e)g|png|tiff|gif)");
-      string output_name = file_regex.replace (path, -1, 0,"") + ".wp.png";
-      make_image (path, output_name);
+      try {
+          var file_regex = new GLib.Regex (".(jpe?g|png|tiff|gif)$");
+          string output_name = file_regex.replace (path, path.length, 0,"") + ".wp.png";
+          make_image (path, output_name);
+      } catch (RegexError e) {
+          stdout.printf ("Error on file: %s", e.message);
+      }
     }
 
     public static void make_image (string input, string output) {

--- a/src/Wallpaperize.vala
+++ b/src/Wallpaperize.vala
@@ -17,9 +17,18 @@ public class Wallpaperize.Wallpaperiser : Object {
           var file_regex = new GLib.Regex (".(jpe?g|png|tiff|gif)$");
           string output_name = file_regex.replace (path, path.length, 0,"") + ".wp.png";
           make_image (path, output_name);
+          set_wallpaper (output_name);
       } catch (RegexError e) {
           stdout.printf ("Error on file: %s", e.message);
       }
+    }
+
+    // from switchboard-plug-pantheon-shell set-wallpaper.vala
+    public static void set_wallpaper (string uri) {
+        var settings = new Settings ("org.gnome.desktop.background");
+        settings.set_string ("picture-uri", uri);
+        settings.apply ();
+        Settings.sync ();
     }
 
     public static void make_image (string input, string output) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -167,8 +167,7 @@ public class Wallpaperize.Window : Gtk.ApplicationWindow {
   }
 
   private void get_screen_size () {
-      Wallpaperize.Wallpaperiser.H = Gdk.Screen.height ();
-      Wallpaperize.Wallpaperiser.W = Gdk.Screen.width ();
+      Wallpaperize.Wallpaperiser.get_monitor_geometry();
 
       width.text = Wallpaperize.Wallpaperiser.W.to_string ();
       height.text = Wallpaperize.Wallpaperiser.H.to_string ();

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -167,7 +167,7 @@ public class Wallpaperize.Window : Gtk.ApplicationWindow {
   }
 
   private void get_screen_size () {
-      Wallpaperize.Wallpaperiser.get_monitor_geometry();
+      Wallpaperize.Wallpaperiser.get_monitor_geometry ();
 
       width.text = Wallpaperize.Wallpaperiser.W.to_string ();
       height.text = Wallpaperize.Wallpaperiser.H.to_string ();


### PR DESCRIPTION
The images output to 1920x1080 when ran from Files or command line. This just grabs the screen height/width before processing the file.

The change to Wallpaperize.vala is just cosmetic and may not be wanted.