### PR TITLE
Fix fatal warnings are shown

### DIFF
--- a/src/Window.vala
+++ b/src/Window.vala
@@ -52,6 +52,10 @@ public class Wallpaperize.Window : Gtk.Window {
 
       set {
           _file = value;
+          if (value == null) {
+            return;
+          }
+
           var surface = Wallpaperize.Wallpaperiser.make_surface (value.get_path ());
 
           if (surface != null) {


### PR DESCRIPTION
Fixes #20
Supersedes #21

Check whether `_file` is null before getting its path.
