### PR TITLE
MainWindow: Fix build failing

### DIFF
--- a/src/Window.vala
+++ b/src/Window.vala
@@ -44,7 +44,7 @@ public class Wallpaperize.Window : Gtk.Window {
   public Gtk.Entry width;
   public Gtk.Entry height;
 
-  private File? _file;
+  private File? _file = null;
   public File? file {
       get {
           return _file;
@@ -70,8 +70,6 @@ public class Wallpaperize.Window : Gtk.Window {
             validate ();
           }
       }
-
-      default = null;
   }
 
   public Window (Gtk.Application app) {


### PR DESCRIPTION
Fixes #26

I'm on Horus Beta which comes with valac 0.56.3 and the build failing with the following message:

```
../src/Window.vala:48.3-48.19: error: Property `Wallpaperize.Window.file' with custom `get' accessor and/or `set' mutator cannot have `default' value
   48 |   public File? file {
      |   ^~~~~~~~~~~~~~~~~  
```